### PR TITLE
Extract RMSE and spectral bandwidth information.

### DIFF
--- a/Jacob.py
+++ b/Jacob.py
@@ -1,0 +1,32 @@
+import numpy as np
+import librosa
+
+class Jacob:
+    def __init__(self):
+        pass
+
+    def __str__(self):
+        return "RMSE, RMSE Variance, RMSE STD" \
+                ", Median Spectral Bandwidth, Spectral Bandwidth Variance, Spectral Bandwidth STD"
+
+    def rmse(self, section, frame_length):
+        unframed_rmse = librosa.feature.rmse(y=section.astype(float), frame_length=frame_length)
+        rmse = unframed_rmse[0,0]
+        framed_rmse = librosa.feature.rmse(y=section.astype(float))
+        rmse_variance = np.var(framed_rmse)
+        rmse_std = np.std(framed_rmse)
+        return [rmse, rmse_variance, rmse_std]
+
+    def bandwidth(self, section, sr):
+        framed_bandwidth = librosa.feature.spectral_bandwidth(y=section.astype(float), sr=float(sr))
+        median_bandwidth = np.median(framed_bandwidth)
+        bandwidth_variance = np.var(framed_bandwidth)
+        bandwidth_std = np.std(framed_bandwidth)
+        return [median_bandwidth, bandwidth_variance, bandwidth_std]
+
+    def extract(self, section, full, sr):
+        frame_length = section.shape[0]
+        features = []
+        features += self.rmse(section, frame_length)
+        features += self.bandwidth(section, sr)
+        return features


### PR DESCRIPTION
The RMSE is calculated for the entire provided section. Then, the frame-by-frame RMSE is calculated using the default frame length (2048). The framed RMSE is used to calculate the variance and standard deviation of the RMSE.

The frame-by-frame spectral bandwidth is calculated using the default frame length (2048). The framed bandwidth is used to calculate the median, variance and standard deviation of the spectral bandwidth.